### PR TITLE
Stub out a Get Involved section for README

### DIFF
--- a/CONDUCT.md
+++ b/CONDUCT.md
@@ -1,3 +1,73 @@
-# Code of Conduct
+# Contributor Covenant Code of Conduct
 
-This stub resource is a work in progress.
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of experience,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at `hi@talkto.nyc`. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org

--- a/CONDUCT.md
+++ b/CONDUCT.md
@@ -1,0 +1,3 @@
+# Code of Conduct
+
+This stub resource is a work in progress.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,3 @@
+# Contributing Guidelines
+
+This stub resource is a work in progress.

--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ If you'd like to join in on the conversation, great!
       * General (English): `#general-en`, `#north-america`
       * Other (Mixed): `#vtaiwan`, `#intl`
 3. Review the current list of projects and work with us!
-    * Visit our [public Kanban board][kanban] used to track the status of our many projects
-    * Visit our [GitHub organization][github] used to host our open-source software and all
-      important documents
+    * Visit our [public Kanban board][kanban] used to track the status of our projects
+    * Visit our [GitHub organization][github] used to host our
+      open-source software and other resources
 4. [Join us][video-calls] for a video call stand-up meeting, daily at 11am
    ET.
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,31 @@
-# hub
-Documentation, knowledge hub for g0vNYC project. 
+# g0v.nyc
+[![Slack badge](http://join.g0v.today/badge.svg)](http://join.g0v.today)
+
+## Get Involved
+
+If you'd like to join in on the conversation, great!
+
+1. Review our [Contributor Guidelines][contributing] and [Code of
+   Conduct][conduct].
+2. [Sign up][join-g0v] for the Slack chat tool run by [g0v][about-g0v].
+    * Don't be alarmed that most channels are in mandarin! (g0v is a
+      really rad civil society group that originates in Taiwan.)
+    * Key places for conversation are:
+      * vNYC: `#vnyc-daily`, `#vnyc`, `#vnyc-grants-conf`, `#vnyc-articles`
+      * General (English): `#general-en`, `#north-america`
+      * Other (Mixed): `#vtaiwan`, `#intl`
+3. Review the current list of projects and work with us!
+    * Visit our [public Kanban board][kanban] used to track the status of our many projects
+    * Visit our [GitHub organization][github] used to host our open-source software and all
+      important documents
+4. [Join us][video-calls] for a video call stand-up meeting, daily at 11am
+   ET.
+
+<!-- Links -->
+   [contributing]: CONTRIBUTING.md
+   [conduct]: CONDUCT.md
+   [join-g0v]: http://join.g0v.today/
+   [about-g0v]: http://g0v.asia/
+   [video-calls]: https://appear.in/vnyc
+   [kanban]: https://trello.com/b/6MHFIpnA/g0vnyc-community-onboarding
+   [github]: https://github.com/g0vnyc

--- a/README.md
+++ b/README.md
@@ -5,23 +5,26 @@
 
 If you'd like to join in on the conversation, great!
 
-1. Review our [Contributor Guidelines][contributing] and [Code of
+1. Read the Civicist article that brought us together: <br />
+    [vTaiwan: Public Participation Methods on the Cyberpunk Frontier of Democracy][civicist]
+2. Review our [Contributor Guidelines][contributing] and [Code of
    Conduct][conduct].
-2. [Sign up][join-g0v] for the Slack chat tool run by [g0v][about-g0v].
+3. [Sign up][join-g0v] for the Slack chat tool run by [g0v][about-g0v].
     * Don't be alarmed that most channels are in mandarin! (g0v is a
       really rad civil society group that originates in Taiwan.)
     * Key places for conversation are:
       * vNYC: [`#vnyc-daily`][slack-vnyc-daily], [`#vnyc`][slack-vnyc], [`#vnyc-grants-conf`][slack-vnyc-grants-conf], [`#vnyc-articles`][slack-vnyc-articles]
       * General (English): `#general-en`, `#north-america`
       * Other (Mixed): `#vtaiwan`, `#intl`
-3. Review the current list of projects and work with us!
+4. Review the current list of projects and work with us!
     * Visit our [public Kanban board][kanban] used to track the status of our projects
     * Visit our [GitHub organization][github] used to host our
       open-source software and other resources
-4. [Join us][video-calls] for a video call stand-up meeting, daily at 11am
+5. [Join us][video-calls] for a video call stand-up meeting, daily at 11am
    ET.
 
 <!-- Links -->
+   [civicist]: https://civichall.org/civicist/vtaiwan-democracy-frontier/
    [contributing]: CONTRIBUTING.md
    [conduct]: CONDUCT.md
    [join-g0v]: http://join.g0v.today/

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ If you'd like to join in on the conversation, great!
     * Don't be alarmed that most channels are in mandarin! (g0v is a
       really rad civil society group that originates in Taiwan.)
     * Key places for conversation are:
-      * vNYC: `#vnyc-daily`, `#vnyc`, `#vnyc-grants-conf`, `#vnyc-articles`
+      * vNYC: [`#vnyc-daily`][slack-vnyc-daily], [`#vnyc`][slack-vnyc], [`#vnyc-grants-conf`][slack-vnyc-grants-conf], [`#vnyc-articles`][slack-vnyc-articles]
       * General (English): `#general-en`, `#north-america`
       * Other (Mixed): `#vtaiwan`, `#intl`
 3. Review the current list of projects and work with us!
@@ -29,3 +29,7 @@ If you'd like to join in on the conversation, great!
    [video-calls]: https://appear.in/vnyc
    [kanban]: https://trello.com/b/6MHFIpnA/g0vnyc-community-onboarding
    [github]: https://github.com/g0vnyc
+   [slack-vnyc-daily]: https://g0v-tw.slackarchive.io/vnyc-daily/
+   [slack-vnyc]: https://g0v-tw.slackarchive.io/vnyc/
+   [slack-vnyc-grants-conf]: https://g0v-tw.slackarchive.io/vnyc-grants-conf/
+   [slack-vnyc-articles]: https://g0v-tw.slackarchive.io/vnyc-articles/


### PR DESCRIPTION
Could use a picky once-over, but thinking something is better than nothing, and didn't want to delay again.

1. is the email in the code of conduct the right one?
2. is there a public kanban board we could link?
3. can we make the trello team itself public, just to have one place wher all
public trello board will always be visible? (though def not suggesting opening
boards should be taken lightly)
4. How should we frame the standup / video call?
5. anything else?